### PR TITLE
Check MK 1.6

### DIFF
--- a/fortigate_wtp/README.MD
+++ b/fortigate_wtp/README.MD
@@ -18,6 +18,9 @@ Install the package.
 - Performance Metrics: State, CPU, RAM, Traffic In/Out
 - Alerts: only on State
 
+## Version 1.3 ##
+Compatibility with CheckMK 1.6
+
 ## Version 1.2 ##
 Removed unused python imports, thanks to Simon Betz
 

--- a/fortigate_wtp/fortigate_wtp
+++ b/fortigate_wtp/fortigate_wtp
@@ -11,7 +11,7 @@ fortigate_wtp_status_map = { '0': 'Other', '1': 'Offline', '2': 'Online', '3': '
 fortigate_wtp_status2nagios_map = { 'Online': 0, 'DownloadingImage': 1, 'ConnectedImage': 1, 'Offline': 2, 'Other': 2 }
 
 
-def inventory_fortigate_wtp(checkname, info):
+def inventory_fortigate_wtp(info):
     if info and len(info) > 0 and info[0] != '':
         inventory = []
         for wtpid, wtpconnstate, wtpstations, wtprx, wtptx, wtpcpu, wtpmem, wtpname in info:

--- a/fortigate_wtp/fortigate_wtp
+++ b/fortigate_wtp/fortigate_wtp
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- encoding: utf-8; py-indent-offset: 4 -*-
+# v1.3 - removed first parameter at inventory call | SBI
 # v1.2 - removed unused python imports, thanks to Simon Betz
 # v1.1 - fixed OIDs and added some readings
 # Author: Davide Del Grande <davide.delgrande _ lanewan.it> / <delgrande.davide _ gmail.com>

--- a/fortigate_wtp/fortigate_wtp-1.2
+++ b/fortigate_wtp/fortigate_wtp-1.2
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+# -*- encoding: utf-8; py-indent-offset: 4 -*-
+# v1.3 - removed first parameter at inventory call | SBI
+# v1.2 - removed unused python imports, thanks to Simon Betz
+# v1.1 - fixed OIDs and added some readings
+# Author: Davide Del Grande <davide.delgrande _ lanewan.it> / <delgrande.davide _ gmail.com>
+
+# wtpstate: connection state of a WTP to AC :
+# other(0), offLine(1), onLine(2), downloadingImage(3), connectedImage(4)
+
+fortigate_wtp_status_map = { '0': 'Other', '1': 'Offline', '2': 'Online', '3': 'DownloadingImage', '4': 'ConnectedImage' }
+fortigate_wtp_status2nagios_map = { 'Online': 0, 'DownloadingImage': 1, 'ConnectedImage': 1, 'Offline': 2, 'Other': 2 }
+
+
+def inventory_fortigate_wtp(checkname, info):
+    if info and len(info) > 0 and info[0] != '':
+        inventory = []
+        for wtpid, wtpconnstate, wtpstations, wtprx, wtptx, wtpcpu, wtpmem, wtpname in info:
+            inventory.append( (wtpid, "", None) )
+
+        return inventory
+
+
+def check_fortigate_wtp(item, _no_params, info):
+    for wtpid, wtpconnstate, wtpstations, wtprx, wtptx, wtpcpu, wtpmem, wtpname in info:
+        if wtpid == item:
+            wtp_status = fortigate_wtp_status_map[wtpconnstate]
+            nagstatus  = fortigate_wtp_status2nagios_map[wtp_status]
+
+            this_time = int(time.time())
+
+            rx_counter = int(wtprx)
+            rx_per_sec = get_rate("fortigate_wtp.%s.rx" % item, this_time, rx_counter)
+            rx_outputline = "%s/sec" % get_bytes_human_readable(rx_per_sec)
+
+            tx_counter = int(wtptx)
+            tx_per_sec = get_rate("fortigate_wtp.%s.tx" % item, this_time, tx_counter)
+            tx_outputline = "%s/sec" % get_bytes_human_readable(tx_per_sec)
+
+
+            perfdata = [("CPU", wtpcpu),
+                        ("Memory", wtpmem),
+                        ("Stations", wtpstations),
+                        ("Bandwidth_Rx", rx_per_sec),
+                        ("Bandwidth_Tx", tx_per_sec),]
+
+            output = "Name:%s - State:%s CPU:%s%% RAM:%s%% Stations:%s Rx:%s Tx:%s" % (wtpname, wtp_status, wtpcpu, wtpmem, wtpstations, rx_outputline, tx_outputline)
+
+            return (nagstatus, output, perfdata)
+
+
+check_info["fortigate_wtp"] = {
+    "check_function"        : check_fortigate_wtp,
+    "inventory_function"    : inventory_fortigate_wtp,
+    "service_description"   : "WTP",
+    "has_perfdata"          : True,
+    "snmp_scan_function"    : lambda oid: oid(".1.3.6.1.4.1.12356.101.14.2.4.0"),
+    "snmp_info"             : (".1.3.6.1.4.1.12356.101.14.4", [
+                                    "4.1.1",	# fgWcWtpSessionWtpId
+                                    "4.1.7",	# fgWcWtpSessionConnectionState
+                                    "4.1.17",	# fgWcWtpSessionWtpStationCount
+                                    "4.1.18",	# fgWcWtpSessionWtpByteRxCount
+                                    "4.1.19",	# fgWcWtpSessionWtpByteTxCount
+                                    "4.1.20",	# fgWcWtpSessionWtpCpuUsage
+                                    "4.1.21",	# fgWcWtpSessionWtpMemoryUsage
+                                    "3.1.3",	# fgWcWtpConfigWtpName
+                                ]),
+}


### PR DESCRIPTION
Hi Davide

I am very greatful for the accesspoint plugin and wanted to rather right away correct the inventory call instead of just opening an issue:

I removed the attribute checkname from the function inventory_fortigate_wtp, since it's not compatible with checkmk 1.6 anymore.

I'm new to github and hope I didn't mess up too much. Feel free to reject my request and do the change yourself if I did :)

Best
Simon